### PR TITLE
Change license to Apache 2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3"
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -35,7 +35,7 @@ test:
 
 about:
   home: http://www.erlang.org/
-  license: Erlang Public License 1.1 (http://www.erlang.org/EPLICENSE)
+  license: Apache 2.0
   summary: "A programming language used to build massively scalable soft real-time systems with requirements on high availability."
 
 extra:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/erlang-feedstock/issues/2

Appears that we missed that Erlang is no longer under the Erlang Public License 1.1, but is now under Apache 2.0. This happened in [version 18]( https://www.erlang.org/about ). Build number updated to fix metadata as displayed on the [package page]( https://anaconda.org/conda-forge/erlang ).