### PR TITLE
Pin `ncurses` to 5.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3"
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -19,13 +19,13 @@ requirements:
     - perl
     - readline 6.2*
     - openssl 1.0.*
-    - ncurses
+    - ncurses 5.9*
     - zlib 1.2*
     - libatomic_ops
   run:
     - readline 6.2*
     - openssl 1.0.*
-    - ncurses
+    - ncurses 5.9*
     - zlib 1.2*
     - libatomic_ops
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/erlang-feedstock/issues/5

Simply follows the pinning guidelines and pins this to 5.9.