### PR TITLE
Trap SIGTERM from the test suite (if present)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,6 @@ export ERL_TOP="$(pwd)"
 make
 make release_tests
 cd "${ERL_TOP}/release/tests/test_server"
-${ERL_TOP}/bin/erl -s ts install -s ts smoke_test batch -s init stop
+trap "${ERL_TOP}/bin/erl -s ts install -s ts smoke_test batch -s init stop" 15
 cd ${ERL_TOP}
 make install


### PR DESCRIPTION
Tries to trap a SIGTERM that could be coming from the test suite based on a [suggestion]( https://github.com/conda-forge/erlang-feedstock/issues/1#issuecomment-217700220 ) in this issue ( https://github.com/conda-forge/erlang-feedstock/issues/1 ).