### PR TITLE
Build from GitHub archive

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@
 export LIBRARY_PATH="${PREFIX}/lib:${LIBRARY_PATH}"
 export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
 export ERL_TOP="$(pwd)"
+./otp_build autoconf
 ./configure --with-ssl="${PREFIX}" --prefix="${PREFIX}" --without-javac \
   --with-libatomic_ops="${PREFIX}" --enable-m${ARCH}-build
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: otp_src_{{ version }}.tar.gz
-  url: http://erlang.org/download/otp_src_{{ version }}.tar.gz
-  sha256: "fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3"
+  url: https://github.com/erlang/otp/archive/OTP-{{ version }}.tar.gz
+  sha256: 8d5436faf37a1273c1b8529c4f02c28af0eccde31e52d474cb740b012d5da7e6
   patches:
     # Adds a patch to pickup `perl` from the path instead of
     # forcing it to come from `/usr/bin`. See PR for details.
@@ -17,11 +17,12 @@ source:
     - PR_1097.diff
 
 build:
-  number: 5
+  number: 6
   skip: true  # [win]
 
 requirements:
   build:
+    - autoconf
     - m4
     - perl
     - readline 6.2*


### PR DESCRIPTION
This builds directly from source. In addition to generally being a good idea to build from source, this is being proposed due to some issues downloading from the download URL provided. See this [build]( https://circleci.com/gh/conda-forge/erlang-feedstock/43 ) for an example of these download issues. However, we seem to be able to download this via the browser. Not sure exactly what the issue is. Perhaps they are trying to keep better track of who is downloading Erlang. In any event, this sidesteps that issue by building from source.