### PR TITLE
Fix cross-compilation osx-arm64 build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 ncurses:
 - '6'
 openssl:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,10 +6,8 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 ncurses:
 - '6'
 openssl:
@@ -35,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 ncurses:
 - '6'
 openssl:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"
@@ -33,7 +34,7 @@ rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
 ( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-
+echo "Activating environment"
 source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,13 +28,13 @@ function bootstrap_build {
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
   LDFLAGS_CROSS=$LDFLAGS
-  export LDFLAGS='-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$BUILD_PREFIX/lib -L$BUILD_PREFIX/lib'
+  export LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" LDFLAGS='-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$BUILD_PREFIX/lib -L$BUILD_PREFIX/lib' ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,10 +37,12 @@ function bootstrap_build {
       --host="${BUILD}" \
       --without-javac \
       --disable-builtin-zlib \
-      || { cat make/config.log ; exit 1; }
+      || { cat make/config.log; cat erts/config.log; exit 1; }
 
-  echo "Boostrap build config.log"
+  echo "======== Boostrap build config.log ==========="
   cat make/config.log
+  echo "======== ERTS build config.log ==========="
+  cat erts/config.log
   make -j "$CPU_COUNT"
 }
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,12 +30,13 @@ function bootstrap_build {
   PREFIX_CROSS=$PREFIX
   export PREFIX="${BUILD_PREFIX}"
   ls $BUILD_PREFIX
+  echo $LDFLAGS
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" CPPFLAGS="$CPPFLAGS -isystem $BUILD_PREFIX/include" ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,20 +20,21 @@ function bootstrap_build {
   # the bootstrap system needs to be compiled with the guest (x86) toolchain.
   # Otherwise, configure fails with:
   # error: Cannot both cross compile and build a bootstrap system
-  local CC CXX CPP LD AR RANLIB LDFLAGS_FOR_BUILD
+  local CC CXX CPP LD AR RANLIB LDFLAGS_CROSS
   CC=${CC_FOR_BUILD}
   CXX=${CXX_FOR_BUILD}
   CPP=${CPP_FOR_BUILD}
   LD=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ld/')
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
-  LDFLAGS_FOR_BUILD=${LDFLAGS//PREFIX/BUILD_PREFIX}
+  LDFLAGS_CROSS=$LDFLAGS
+  LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" LDFLAGS="$LDFLAGS_FOR_BUILD" ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \
@@ -45,6 +46,7 @@ function bootstrap_build {
   echo "======== ERTS build config.log ==========="
   cat erts/config.log
   make -j "$CPU_COUNT"
+  LDFLAGS=$LDFLAGS_CROSS
 }
 
 # For builds that are cross-compiled (aarch64), we need to build a bootstrap system first.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,7 +29,7 @@ function bootstrap_build {
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
   PREFIX_CROSS=$PREFIX
   export PREFIX="${BUILD_PREFIX}"
-  ls $BUILD_PREFIX
+  ls $BUILD_PREFIX/lib
   echo $LDFLAGS
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
@@ -38,7 +38,7 @@ function bootstrap_build {
   # https://github.com/erlang/otp/pull/8862
   CFLAGS="-O1" CXXFLAGS="-O1" \
   CPPFLAGS="$CPPFLAGS -isystem $BUILD_PREFIX/include" \
-  LDFLAGS="$LDFLAGS -L$BUILD_PREFIX/lib" \
+  LDFLAGS="-L$BUILD_PREFIX/lib" \
   ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,8 +23,8 @@ function bootstrap_build {
   local CC CXX CPP LD AR RANLIB
   CC=${CC_FOR_BUILD}
   CXX=${CXX_FOR_BUILD}
+  CPP=${CPP_FOR_BUILD}
   LD=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ld/')
-  CPP=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-cpp/')
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
   CFLAGS="-O1" CXXFLAGS="-O1" ./configure \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,7 @@ function bootstrap_build {
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
   LDFLAGS_CROSS=$LDFLAGS
-  LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
+  export LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
@@ -46,7 +46,7 @@ function bootstrap_build {
   echo "======== ERTS build config.log ==========="
   cat erts/config.log
   make -j "$CPU_COUNT"
-  LDFLAGS=$LDFLAGS_CROSS
+  export LDFLAGS=$LDFLAGS_CROSS
 }
 
 # For builds that are cross-compiled (aarch64), we need to build a bootstrap system first.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,10 +27,16 @@ function bootstrap_build {
   LD=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ld/')
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
+
+  # NOTE: clang-18 exposes an issue with outdated vendored zlib,
+  # so we need to use the system zlib instead, at least until new erlang
+  # release which will have updated zlib 1.3.1, see:
+  # https://github.com/erlang/otp/pull/8862
   CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \
+      --disable-builtin-zlib \
       || { cat make/config.log ; exit 1; }
 
   echo "Boostrap build config.log"
@@ -46,7 +52,6 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" -eq 1 ]]; then
   # https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md#cross-system-root-locations
   export erl_xcomp_sysroot="${CONDA_BUILD_SYSROOT}"
 fi
-
 ./configure \
     --prefix="${PREFIX}" \
     --with-ssl="${PREFIX}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,7 +36,10 @@ function bootstrap_build {
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" CPPFLAGS="$CPPFLAGS -isystem $BUILD_PREFIX/include" ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" \
+  CPPFLAGS="$CPPFLAGS -isystem $BUILD_PREFIX/include" \
+  LDFLAGS="$LDFLAGS -L$BUILD_PREFIX/lib" \
+  ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,13 +28,13 @@ function bootstrap_build {
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
   LDFLAGS_CROSS=$LDFLAGS
-  export LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
+  export LDFLAGS='-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$BUILD_PREFIX/lib -L$BUILD_PREFIX/lib'
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" LDFLAGS='-Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$BUILD_PREFIX/lib -L$BUILD_PREFIX/lib' ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,19 +20,20 @@ function bootstrap_build {
   # the bootstrap system needs to be compiled with the guest (x86) toolchain.
   # Otherwise, configure fails with:
   # error: Cannot both cross compile and build a bootstrap system
-  local CC CXX CPP LD AR RANLIB
+  local CC CXX CPP LD AR RANLIB LDFLAGS_FOR_BUILD
   CC=${CC_FOR_BUILD}
   CXX=${CXX_FOR_BUILD}
   CPP=${CPP_FOR_BUILD}
   LD=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ld/')
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
+  LDFLAGS_FOR_BUILD=${LDFLAGS//PREFIX/BUILD_PREFIX}
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
   # release which will have updated zlib 1.3.1, see:
   # https://github.com/erlang/otp/pull/8862
-  CFLAGS="-O1" CXXFLAGS="-O1" ./configure \
+  CFLAGS="-O1" CXXFLAGS="-O1" LDFLAGS="$LDFLAGS_FOR_BUILD" ./configure \
       --enable-bootstrap-only \
       --host="${BUILD}" \
       --without-javac \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,15 +20,16 @@ function bootstrap_build {
   # the bootstrap system needs to be compiled with the guest (x86) toolchain.
   # Otherwise, configure fails with:
   # error: Cannot both cross compile and build a bootstrap system
-  local CC CXX CPP LD AR RANLIB LDFLAGS_CROSS
+  local CC CXX CPP LD AR RANLIB PREFIX_CROSS
   CC=${CC_FOR_BUILD}
   CXX=${CXX_FOR_BUILD}
   CPP=${CPP_FOR_BUILD}
   LD=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ld/')
   AR=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ar/')
   RANLIB=$(echo "${CC_FOR_BUILD}" | sed -E 's/-(cc|clang)$/-ranlib/')
-  LDFLAGS_CROSS=$LDFLAGS
-  export LDFLAGS="${LDFLAGS//PREFIX/BUILD_PREFIX}"
+  PREFIX_CROSS=$PREFIX
+  export PREFIX="${BUILD_PREFIX}"
+  ls $BUILD_PREFIX
 
   # NOTE: clang-18 exposes an issue with outdated vendored zlib,
   # so we need to use the system zlib instead, at least until new erlang
@@ -46,7 +47,7 @@ function bootstrap_build {
   echo "======== ERTS build config.log ==========="
   cat erts/config.log
   make -j "$CPU_COUNT"
-  export LDFLAGS=$LDFLAGS_CROSS
+  export PREFIX=$PREFIX_CROSS
 }
 
 # For builds that are cross-compiled (aarch64), we need to build a bootstrap system first.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - {{ compiler("cxx") }}
     - gnuconfig
     - make
+    - zlib            # [build_platform != target_platform]
   host:
     - perl
     - readline

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 365208d47f9590f27c0814ccd7ee7aec0e1b6ba2fe9d875e356edb5d9b054541
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

The conda-forge compilation environment now provides `CPP_FOR_BUILD` envvar so we can use it for our x86 bootstrap build.

Previously, we needed to guess it from the CC_FOR_BUILD, and apparently the guess has become wrong, since we would guess 
`$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-cpp`
but now it apparently changed to
`$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang-cpp`

EDIT: Looks like `CPP_FOR_BUILD` has been introduced here: https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/149